### PR TITLE
Remove as() and improve rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -405,14 +405,15 @@ Redirects to route('login') if unauthenticated.
 Filter::make('like')->exists()->auth(),
 ```
 
-## Adding a query parameter name
+## Using a different public key
 
-When the filter key is different than the query parameter
+A url key different from the relationship or column name
 ```php
-Filter::make('status_column')->as('status'),
+Filter::make('status', 'status_id'),
+Filter::make('author', 'activeAuthor'),
 ```
 ```
-/articles?status=active
+/articles?status=1
 ```
 
 ## Adding a multiple values

--- a/tests/Fixtures/ListPostRequest.php
+++ b/tests/Fixtures/ListPostRequest.php
@@ -44,38 +44,41 @@ class ListPostRequest extends ListRequest
             Filter::make('like')->exists()->auth(),
             Filter::make('length')->range(),
             Filter::make('author')->related(),
-            Filter::make('author')->as('writer')->related()->multiple(),
+            Filter::make('writer', 'author')->related()->multiple(),
             Filter::make('active')->boolean(),
-            Filter::make('active')->as('toggle')->toggle(),
+            Filter::make('toggle', 'active')->toggle(),
             Filter::make('comments')->exists(),
             Filter::make('comments')->count(),
             Filter::make('comments')->countRange(),
             Filter::make('published_at')->date(),
-            Filter::make('published_at')->as('multiple_dates')->date()->multiple(),
+            Filter::make('multiple_dates', 'published_at')->date()->multiple(),
             Filter::make('created_at')->dateRange(),
             Filter::make('status')->options(['active', 'inactive']),
-            Filter::make('status')->as('multiple')->options(['active', 'inactive'])->multiple(),
+            Filter::make('multiple', 'status')->options(['active', 'inactive'])->multiple(),
             Filter::make('value-scope')->scope('status'),
             Filter::make('active-scope')->scope('active'),
             Filter::make('boolean-scope')->scopeBoolean('activeBoolean'),
             Filter::make('trashed')->onlyTrashed(),
             Filter::make('with-trashed')->withTrashed(),
             Filter::make('written-by')->search(['author.name']),
-            Filter::make('length')
-                ->as('article-size')
+            Filter::make('article-size', 'length')
                 ->when('50', function ($query) {
                     $query->where('length', '50');
                 })->when('100', function ($query) {
                     $query->where('length', '100');
                 }),
 
-            Filter::make('length')
+            Filter::make('length-range', 'length')
                 ->between('small', [1,10])
                 ->between('medium', [11,20])
-                ->between('large', [21,30])
-                ->as('length-range'),
+                ->between('large', [21,30]),
 
-            Filter::make('length')->as('money')->cents()
+            Filter::make('length-range', 'length')
+                ->between('small', [1,10])
+                ->between('medium', [11,20])
+                ->between('large', [21,30]),
+
+            Filter::make('money', 'length')->cents(),
         ];
     }
 

--- a/tests/ListRequestTest.php
+++ b/tests/ListRequestTest.php
@@ -796,10 +796,9 @@ class ListRequestTest extends TestCase
 
     public function test_rules_appending_with_public_key()
     {
-        $filter = Filter::make('append-rules')
+        $filter = Filter::make('other-name', 'append-rules')
             ->options(['1', '2', '3'])
-            ->withRules('gt:2')
-            ->as('other-name');
+            ->withRules('gt:2');
 
         $rules = $filter->getRules();
 


### PR DESCRIPTION
I decided that `->as()` was less ideal that using a 2nd parameter for overriding the internal key

This key is used for relationships and columns, the same way Laravel Nova handles it.