### PR TITLE
Add belongs to sort

### DIFF
--- a/tests/Fixtures/Database/Factories/UserFactory.php
+++ b/tests/Fixtures/Database/Factories/UserFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Dillingham\Formation\Tests\Fixtures\Database\Factories;
+
+use Dillingham\Formation\Tests\Fixtures\Post;
+use Dillingham\Formation\Tests\Fixtures\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ];
+    }
+}

--- a/tests/Fixtures/PostFormation.php
+++ b/tests/Fixtures/PostFormation.php
@@ -19,6 +19,7 @@ class PostFormation extends Formation
 
     public $sort = [
         'title',
+        'author.name as author_name',
         'comments',
         'comments.upvotes',
         'comments.downvotes as disliked',

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -2,9 +2,9 @@
 
 namespace Dillingham\Formation\Tests\Fixtures;
 
+use Dillingham\Formation\Tests\Fixtures\Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Orchestra\Testbench\Factories\UserFactory;
 
 class User extends Authenticatable
 {

--- a/tests/FormationTest.php
+++ b/tests/FormationTest.php
@@ -11,6 +11,7 @@ use Dillingham\Formation\Tests\Fixtures\Like;
 use Dillingham\Formation\Tests\Fixtures\Post;
 use Dillingham\Formation\Tests\Fixtures\PostFormation;
 use Dillingham\Formation\Tests\Fixtures\Tag;
+use Dillingham\Formation\Tests\Fixtures\User;
 use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -124,7 +125,49 @@ class FormationTest extends TestCase
             ->assertJsonPath('data.2.title', '3');
     }
 
-    public function test_sorting_relationships()
+    public function test_sorting_relationships_belongs_to()
+    {
+        $abby = User::factory()->create(['name' => 'abby']);
+        $brad = User::factory()->create(['name' => 'brad']);
+        $casey = User::factory()->create(['name' => 'casey']);
+
+        $abbyPost = Post::factory()->create(['author_id' => $abby->id]);
+        $bradPost = Post::factory()->create(['author_id' => $brad->id]);
+        $caseyPost = Post::factory()->create(['author_id' => $casey->id]);
+
+        $this->get('/posts?sort-desc=author.name')
+            ->assertJsonPath('data.2.id', $caseyPost->id)
+            ->assertJsonPath('data.1.id', $bradPost->id)
+            ->assertJsonPath('data.0.id', $abbyPost->id);
+
+        $this->get('/posts?sort=author.name')
+            ->assertJsonPath('data.0.id', $abbyPost->id)
+            ->assertJsonPath('data.1.id', $bradPost->id)
+            ->assertJsonPath('data.2.id', $caseyPost->id);
+    }
+
+    public function test_sorting_relationships_belongs_to_with_alias()
+    {
+        $abby = User::factory()->create(['name' => 'abby']);
+        $brad = User::factory()->create(['name' => 'brad']);
+        $casey = User::factory()->create(['name' => 'casey']);
+
+        $abbyPost = Post::factory()->create(['author_id' => $abby->id]);
+        $bradPost = Post::factory()->create(['author_id' => $brad->id]);
+        $caseyPost = Post::factory()->create(['author_id' => $casey->id]);
+
+        $this->get('/posts?sort-desc=author_name')
+            ->assertJsonPath('data.2.id', $caseyPost->id)
+            ->assertJsonPath('data.1.id', $bradPost->id)
+            ->assertJsonPath('data.0.id', $abbyPost->id);
+
+        $this->get('/posts?sort=author_name')
+            ->assertJsonPath('data.0.id', $abbyPost->id)
+            ->assertJsonPath('data.1.id', $bradPost->id)
+            ->assertJsonPath('data.2.id', $caseyPost->id);
+    }
+
+    public function test_sorting_relationships_has_many()
     {
         $threeComments = Post::factory()->has(
             Comment::factory()->count(3)
@@ -149,7 +192,7 @@ class FormationTest extends TestCase
             ->assertJsonPath('data.2.id', $threeComments->id);
     }
 
-    public function test_sorting_relationship_columns()
+    public function test_sorting_relationship_has_many_columns()
     {
         $twoUpvote = Post::factory()->create();
         $oneUpvote = Post::factory()->create();
@@ -170,7 +213,7 @@ class FormationTest extends TestCase
             ->assertJsonPath('data.2.id', $sixUpvote->id);
     }
 
-    public function test_sorting_relationship_column_with_alias()
+    public function test_sorting_relationship_has_many_column_with_alias()
     {
         $twoDownvote = Post::factory()->create();
         $oneDownvote = Post::factory()->create();


### PR DESCRIPTION
BadMethodCallException
Call to undefined method Illuminate\Database\Eloquent\Relations\BelongsTo::getLocalKeyName()
products?sort=brand_title

This PR reproduces that bug
https://github.com/dillingham/formation/runs/3971149661?check_suite_focus=true#step:7:20